### PR TITLE
Add fixed width and height features on the TextPad context menu

### DIFF
--- a/MainApp.cpp
+++ b/MainApp.cpp
@@ -1,6 +1,13 @@
 #include "MainApp.h"
 
 
+/*
+ * Problems need to be optimized: 
+	
+
+ */
+
+
 bool MainApp::OnInit(void) {
 	wxInitAllImageHandlers();
 	MainFrame* mainFrame = new MainFrame(nullptr, -1, "Note Holder", APP_POS, APP_SIZE);

--- a/NoteHolderPanel.cpp
+++ b/NoteHolderPanel.cpp
@@ -48,7 +48,7 @@ void NoteHolderPanel::Init(wxWindow* parent, wxString panelName) {
 	this->Bind(wxEVT_RIGHT_DOWN, &NoteHolderPanel::OnPanelMouseRightDown, this);
 #pragma endregion
 
-
+	this->SetName("NoteHolderPanel");
 }
 /**************************************************************************
 *							PRIVATE MEMBER								  *
@@ -58,7 +58,7 @@ void NoteHolderPanel::BuildContextMenu(void) {
 	wxMenu* addSubMenu = new wxMenu();
 
 	auto add = m_contextMenu->AppendSubMenu(addSubMenu, wxString::FromUTF8("Thêm ghi chú"));
-	auto save = m_contextMenu->Append(wxID_ANY, wxString::FromUTF8("Lưu file\tCtrl + S"));
+	auto save = m_contextMenu->Append(wxID_ANY, wxString::FromUTF8("Lưu file này\tCtrl + S"));
 	auto clear = m_contextMenu->Append(wxID_ANY, wxString::FromUTF8("Xóa tất cả ghi chú"));
 	auto miniAll = m_contextMenu->Append(wxID_ANY, wxString::FromUTF8("Thu nhỏ tất cả ghi chú"));
 	auto unMiniAll = m_contextMenu->Append(wxID_ANY, wxString::FromUTF8("Phóng to tất cả ghi chú"));
@@ -111,10 +111,16 @@ void NoteHolderPanel::OnPanelResize(wxSizeEvent& evt) {
 	evt.Skip();
 }
 void NoteHolderPanel::OnPanelScroll(wxMouseEvent& evt) {
+	
 	OnScroll(evt.GetWheelRotation(), evt.ControlDown(), evt.ShiftDown());
 }
 void NoteHolderPanel::OnPanelMouseMove(wxMouseEvent& evt) {
 	auto panel = this;
+	wxPoint mousePos;
+	/*wxWindow* window = wxGetActiveWindow();
+	if (window) {
+		SetStatusText(window->GetName());
+	}*/
 	if (evt.LeftIsDown() && evt.Dragging() && panel->HasCapture()) {
 		//calc delta
 		wxPoint deltaPos = evt.GetPosition() - m_captureMousePos;
@@ -299,6 +305,7 @@ bool NoteHolderPanel::NeedingASave(void) {
 }
 
 void NoteHolderPanel::OnScroll(int wheelRotation, bool ctrlDown, bool shiftDown) {//public scroll for children to access
+	
 	auto panel = this;
 	int scrollStep = 5;
 	int scrollRotation = wheelRotation < 0 ? 1 : -1;

--- a/NoteManager.cpp
+++ b/NoteManager.cpp
@@ -5,8 +5,8 @@
 
 extern void SetStatusText(wxString text, int index = 0);
 /*
-* PENDING: Open File in browser
-*		  - Show absolute location as tooltip on notebook tab
+* PENDING: Open File in browser : done
+*		  - Show absolute location as tooltip on notebook tab (no needed)
 *		  - Fix notebook out of range when application start up
 
 */

--- a/NotePanel.cpp
+++ b/NotePanel.cpp
@@ -9,18 +9,25 @@ extern void SetStatusText(wxString text, int index = 0);
 
 *******************************************************************/
 #define BORDER_SIZE					(3)
-#define MIN_SIZE					(wxSize(150, 60))
 #define NUMBER(x)					(std::stoi(x))
 #define STRING(x)					(std::to_string(x))
 #define PAIR(p)						(std::to_string(p.x) + "," + std::to_string(p.y))
 
-#define DEFAULT_HOVER_COLOR			(wxColour(204, 208, 230))
-#define DEFAULT_HEADER_FONT_SIZE	(14)
-#define DEFAULT_HEADER_FONT			(wxFontInfo(DEFAULT_HEADER_FONT_SIZE))
-#define DEFAULT_CONTENT_FONT_SIZE	(7)
-#define DEFAULT_CONTENT_FONT		(wxFontInfo(DEFAULT_CONTENT_FONT_SIZE))
-#define DEFAULT_PANEL_COLOR			(wxColour(180, 197, 240))
-#define DEFAULT_DRAG_PANEL_COLOR	(wxColour(124, 157, 242))
+#define HOVER_DEFAULT_COLOR			(wxColour(204, 208, 230))
+
+#define HEADER_DEFAULT_MIN_SIZE		(wxSize(50, 36))
+#define HEADER_DEFAULT_FONT_SIZE	(14)
+#define HEADER_DEFAULT_FONT			(wxFontInfo(HEADER_DEFAULT_FONT_SIZE))
+
+#define CONTENT_DEFAULT_FONT_SIZE	(7)
+#define CONTENT_DEFAULT_FONT		(wxFontInfo(CONTENT_DEFAULT_FONT_SIZE))
+
+#define PANEL_DEFAULT_COLOR			(wxColour(180, 197, 240))
+
+#define DRAG_PANEL_DEFAULT_COLOR	(wxColour(124, 157, 242))
+#define DRAG_PANEL_MIN_SIZE			(wxSize(20, 10))
+
+#define BUTTON_DEFAULT_MIN_SIZE		(wxSize(18, 18))
 
 #define CHILD_CHANGED				(m_parent->OnChildChanged())
 
@@ -50,34 +57,33 @@ NotePanel::NotePanel(NoteHolderPanel* parent, NOTE_TYPE_e type){
 }
 void NotePanel::Init(NoteHolderPanel* parent, NOTE_TYPE_e type) {
 	wxPanel::Create(parent, -1, wxDefaultPosition, wxDefaultSize, wxBORDER_SIMPLE);
+#pragma region Init
 	m_parent = parent;
 	m_resizeDirection = NONE;
-	m_headerFontSize = DEFAULT_HEADER_FONT_SIZE;
-	m_contentFontSize = DEFAULT_CONTENT_FONT_SIZE;
-	m_minimizeHoverColor = DEFAULT_HOVER_COLOR;
-	m_closeHoverColor = DEFAULT_HOVER_COLOR;
+	m_headerFontSize = HEADER_DEFAULT_FONT_SIZE;
+	m_contentFontSize = CONTENT_DEFAULT_FONT_SIZE;
+	m_minimizeHoverColor = HOVER_DEFAULT_COLOR;
+	m_closeHoverColor = HOVER_DEFAULT_COLOR;
 	m_isMinimized = false;
 	m_rightDown = false;
-
-
-#pragma region Init
 	m_dragPanel = new wxPanel(this, -1, wxDefaultPosition, wxSize(1, 1));
-	m_headerTC = new wxTextCtrl(this, -1, wxString::FromUTF8("Tiêu đề"), wxDefaultPosition, wxSize(1, 1), wxTE_CENTER | wxTE_NO_VSCROLL | wxBORDER_NONE);
+	m_headerTC = new wxTextCtrl(this, -1, wxString::FromUTF8("Tiêu đề"), wxDefaultPosition, 
+		wxSize(1, 1), wxTE_CENTER | wxBORDER_NONE);
 	CreateNotePad(type);
 	m_miniButton = new wxButton(this, -1, "", wxDefaultPosition, wxSize(1, 1), wxBORDER_NONE);
 	m_closeButton = new wxButton(this, -1, "", wxDefaultPosition, wxSize(1, 1), wxBORDER_NONE);
 
-	m_headerTC->SetMinSize(wxSize(50, 36));
-	m_dragPanel->SetMinSize(wxSize(20, 10));
-	this->SetMinSize(MIN_SIZE);
-	this->SetHeaderFontSize(DEFAULT_HEADER_FONT_SIZE);
-	this->SetContentFontSize(DEFAULT_CONTENT_FONT_SIZE);
-	this->SetColor(DEFAULT_PANEL_COLOR);
-	this->SetDragPanelColor(DEFAULT_DRAG_PANEL_COLOR);
+	m_headerTC->SetMinSize(HEADER_DEFAULT_MIN_SIZE);
+	m_dragPanel->SetMinSize(DRAG_PANEL_MIN_SIZE);
+	this->SetMinSize(NOTE_PANEL_MIN_SIZE);
+	this->SetHeaderFontSize(HEADER_DEFAULT_FONT_SIZE);
+	this->SetContentFontSize(CONTENT_DEFAULT_FONT_SIZE);
+	this->SetColor(PANEL_DEFAULT_COLOR);
+	this->SetDragPanelColor(DRAG_PANEL_DEFAULT_COLOR);
 	m_miniButton->SetBackgroundColour(m_dragPanel->GetBackgroundColour());
-	m_miniButton->SetMinSize(wxSize(18, 18));
+	m_miniButton->SetMinSize(BUTTON_DEFAULT_MIN_SIZE);
 	m_closeButton->SetBackgroundColour(m_dragPanel->GetBackgroundColour());
-	m_closeButton->SetMinSize(wxSize(18, 18));
+	m_closeButton->SetMinSize(BUTTON_DEFAULT_MIN_SIZE);
 #pragma endregion
 
 
@@ -85,13 +91,13 @@ void NotePanel::Init(NoteHolderPanel* parent, NOTE_TYPE_e type) {
 	wxBoxSizer* mainSizerV = new wxBoxSizer(wxVERTICAL);
 	wxBoxSizer* topSizerV = new wxBoxSizer(wxVERTICAL);
 	wxBoxSizer* dragSizerH = new wxBoxSizer(wxHORIZONTAL);
-	dragSizerH->Add(m_dragPanel, 34, wxEXPAND);
-	dragSizerH->Add(m_miniButton, 1);
-	dragSizerH->Add(m_closeButton, 1);
+	dragSizerH->Add(m_dragPanel, 1, wxEXPAND);
+	dragSizerH->Add(m_miniButton, 0);
+	dragSizerH->Add(m_closeButton, 0);
 	topSizerV->Add(dragSizerH, 3, wxEXPAND);
 	topSizerV->Add(m_headerTC, 6, wxEXPAND | wxLEFT | wxRIGHT, BORDER_SIZE);
 	mainSizerV->Add(topSizerV, 0, wxEXPAND);
-	mainSizerV->Add(m_notepad, 10, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, BORDER_SIZE);
+	mainSizerV->Add(m_notepad, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, BORDER_SIZE);
 	this->SetSizer(mainSizerV);
 #pragma endregion
 
@@ -124,22 +130,24 @@ void NotePanel::Init(NoteHolderPanel* parent, NOTE_TYPE_e type) {
 	//m_headerTC
 	{
 		m_headerTC->Bind(wxEVT_TEXT, &NotePanel::OnHeaderTextChanged, this);
-		//m_headerTC->Bind(wxEVT_CHAR_HOOK, &NotePanel::OnCharHook, this);
+		m_headerTC->Bind(wxEVT_CHAR_HOOK, &NotePanel::OnHeaderCharHook, this);
 	}
 
 	//this
 	{
+		this->Bind(wxEVT_SIZE, &NotePanel::OnResize, this);
 		this->Bind(wxEVT_MOTION, &NotePanel::OnMouseMove, this);
 		this->Bind(wxEVT_LEFT_UP, &NotePanel::OnMouseLeftUp, this);
 		this->Bind(wxEVT_LEFT_DOWN, &NotePanel::OnMouseLeftDown, this);
 		this->Bind(wxEVT_LEAVE_WINDOW, &NotePanel::OnMouseLeave, this);
 	}
 
-	BindingEventRecursive(this);
+	//recursive
+	{
+		BindingEventRecursive(this);
+	}
 #pragma endregion
 
-	this->SetMinSize(MIN_SIZE);
-	this->Layout();
 	this->SetDoubleBuffered(true);
 }
 /**************************************************************************
@@ -183,6 +191,21 @@ void NotePanel::SetHeaderText(wxString text){
 void NotePanel::SetContentText(wxString text){
 	m_notepad->SetLabel(text);
 }
+void NotePanel::ResetToDefaultSize(bool resetWidth, bool resetHeight) {
+	wxSize newSize = this->GetSize();
+	if (resetWidth) {
+		newSize.x = DEFAULT_NOTE_PANEL_SIZE.x;
+	}
+	if (resetHeight) {
+		newSize.y = DEFAULT_NOTE_PANEL_SIZE.y;
+	}
+	float zoomFactor = m_parent->GetZoomFactor();
+	m_originRect.SetWidth(newSize.x * zoomFactor);
+	m_originRect.SetHeight(newSize.y * zoomFactor);
+
+	this->UpdateSize();
+	this->Layout();
+}
 
 wxRect& NotePanel::GetOriginRect(void){
 	return m_originRect;
@@ -194,13 +217,15 @@ wxString NotePanel::GetContentText(void){
 	return m_notepad->ToJson();
 }
 
-void NotePanel::UpdateSize(void) {//set the panel size to match with the origin rect size and zoom factor
+void NotePanel::UpdateSize(void) {
+	//set the panel size to match with the origin rect size and zoom factor
 	float zoomFactor = m_parent->GetZoomFactor();
 	wxSize panelSize = m_originRect.GetSize() * zoomFactor;
 	this->SetSize(panelSize);
 	this->Layout();
 }
-void NotePanel::UpdateOnZoom(void) {//update size, position, font size and header alignment based on zoom factor
+void NotePanel::UpdateOnZoom(void) {
+	//update size, position, font size and header alignment based on zoom factor
 	//align left the header when zoom out (0.7f)
 	float zoomFactor = m_parent->GetZoomFactor();
 	if (zoomFactor <= 0.7f) {
@@ -219,19 +244,18 @@ void NotePanel::UpdateOnZoom(void) {//update size, position, font size and heade
 }
 
 //child events
-void NotePanel::OnChildSizeReport(wxSize childSize) {//this function is used when the note panel children wants to change the parent size 
+void NotePanel::OnChildSizeReport(wxSize childSize) {
+	// this function is used when the note panel children wants to change the parent size 
 	float zoomFactor = m_parent->GetZoomFactor();
-	// rescale zoomFactor to get the origin width and height
-	int originWidth = m_originRect.width * 1.0f / zoomFactor;
-	int originHeight = m_originRect.height * 1.0f / zoomFactor;
-	// calculate the ratio between parent and child
-	float widthRatio = originWidth * 1.0f / m_notepad->GetSize().x;
-	float heightRatio = originHeight * 1.0f / m_notepad->GetSize().y;
-	int newWidth = childSize.x * widthRatio;
-	int newHeight = childSize.y * heightRatio;
-	m_originRect.SetWidth(newWidth * zoomFactor);
-	m_originRect.SetHeight(newHeight * zoomFactor);
+	int newWidth = GetChildSizeDiff().x + childSize.x * zoomFactor;
+	int newHeight = GetChildSizeDiff().y + childSize.y * zoomFactor;
+	//clamp the size
+	newWidth = SharedData::Max(newWidth, (int)(NOTE_PANEL_MIN_SIZE.x * zoomFactor));
+	newHeight = SharedData::Max(newHeight, (int)(NOTE_PANEL_MIN_SIZE.y * zoomFactor));
+	m_originRect.SetWidth(newWidth);
+	m_originRect.SetHeight(newHeight);
 	this->UpdateSize();
+
 	CHILD_CHANGED;
 }
 void NotePanel::OnChildChanged(void) {//propagates upward child changed event
@@ -276,12 +300,17 @@ void NotePanel::FromJson(wxString json) {
 	}
 }
 wxString NotePanel::ToJson(void) {
-	if(m_isMinimized == true) SetMinimize(false); // is minimizing, un minimize it before save
+	//if(m_isMinimized == true) SetMinimize(false); // is minimizing, un minimize it before save
+	wxSize noteSize = m_originRect.GetSize();
+	if (m_isMinimized) {
+		//if the note is minimized, take the m_originSize as the note size
+		noteSize = m_originSize;
+	}
 	wxString retStr;
 	retStr += "{";
 	retStr += "\"type\":[" + NotePad::GetTypeString(m_notepad->GetType()) + "],";
 	retStr += "\"pos\":[" + PAIR(m_originRect.GetPosition()) + "],";
-	retStr += "\"size\":[" + PAIR(m_originRect.GetSize()) + "],";
+	retStr += "\"size\":[" + PAIR(noteSize) + "],";
 	retStr += "\"header\":[@\"" + m_headerTC->GetValue() + "\"#],";
 	retStr += m_notepad->ToJson();
 	retStr += "},";
@@ -310,7 +339,7 @@ void NotePanel::SetMinimize(bool minimized) {
 	if (minimized) {//the user asks to minimize
 		if (!m_isMinimized) {//but the note has to be un-minimize
 			m_originSize = m_originRect.GetSize();
-			m_originRect.SetSize(wxSize(m_originRect.GetSize().x, MIN_SIZE.y));
+			m_originRect.SetSize(wxSize(m_originRect.GetSize().x, NOTE_PANEL_MIN_SIZE.y));
 			m_notepad->Hide();
 		}
 	}
@@ -321,18 +350,17 @@ void NotePanel::SetMinimize(bool minimized) {
 		}
 	}
 	m_isMinimized = minimized;
-	this->UpdateOnZoom();
+	this->UpdateSize();
 }
 void NotePanel::BindingEventRecursive(wxWindow* window) {
+	if (window == NULL) return;
 	window->Bind(wxEVT_SET_FOCUS, &NotePanel::OnFocus, this);
 	window->Bind(wxEVT_RIGHT_DOWN, [this](wxMouseEvent& evt) {
 		m_rightDown = true;
 		evt.Skip();
 	});
-	window->Bind(wxEVT_MOUSEWHEEL, [this](wxMouseEvent& evt) {
-		evt.Skip(); 
-		m_parent->OnScroll(evt.GetWheelRotation(), evt.ControlDown(), evt.ShiftDown()); 
-	});
+	//window->GetEvtHandlerEnabled()
+	window->Bind(wxEVT_MOUSEWHEEL, &NotePanel::OnMouseScroll, this);
 
 	auto childs = window->GetChildren();
 	for (auto child : childs) {
@@ -354,6 +382,11 @@ void NotePanel::CreateNotePad(NOTE_TYPE_e type) {
 		break;
 	}
 	this->Layout();
+}
+wxSize NotePanel::GetChildSizeDiff(void) {
+	//this function returns the different between the note size and the child size
+	//which turns out to be the drag panel + header + border size
+	return this->GetSize() - m_notepad->GetSize();
 }
 
 #pragma region Events
@@ -405,8 +438,22 @@ void NotePanel::OnHeaderTextChanged(wxCommandEvent& evt) {//adjust width when us
 	}
 	evt.Skip();
 }
+void NotePanel::OnHeaderCharHook(wxKeyEvent& evt) {
+	//set the note pad to receive tab navigation
+	if (evt.GetKeyCode() == WXK_TAB) {
+		m_notepad->ReceiveTabNavigation();
+	}
+	else {
+		
+		evt.Skip();
+	}
+}
 
-// resizing
+// this - resizing
+void NotePanel::OnResize(wxSizeEvent& evt) {
+	this->Layout();
+	evt.Skip();
+}
 void NotePanel::OnMouseMove(wxMouseEvent& evt){
 	auto panel = this;
 	RESIZE_DIRECTION direction = GetCurrentResizeDirection(evt.GetPosition());
@@ -455,15 +502,15 @@ void NotePanel::OnMouseMove(wxMouseEvent& evt){
 		}
 
 		bool moveX = true;
-		if ((m_prevPanelSize + size).x <= MIN_SIZE.x * m_parent->GetZoomFactor()) {//if min width then no change position on x direction
+		if ((m_prevPanelSize + size).x <= NOTE_PANEL_MIN_SIZE.x * m_parent->GetZoomFactor()) {//if min width then no change position on x direction
 			moveX = false;
 		}
 		if (moveX == true) {
 			m_originRect.SetPosition(m_prevRectPos + pos);
 			this->SetPosition(m_prevPanelPos + pos);
 		}
-		m_originRect.SetSize(ClampMinSize(m_prevRectSize + size, MIN_SIZE));//make sure the size wont below min size even after zooming
-		this->SetSize(ClampMinSize(m_prevPanelSize + size, MIN_SIZE));
+		m_originRect.SetSize(ClampMinSize(m_prevRectSize + size, NOTE_PANEL_MIN_SIZE));//make sure the size wont below min size even after zooming
+		this->SetSize(ClampMinSize(m_prevPanelSize + size, NOTE_PANEL_MIN_SIZE));
 
 		CHILD_CHANGED;
 	}
@@ -497,7 +544,7 @@ void NotePanel::OnMinimizeButtonMouseEnter(wxMouseEvent& evt) {
 	m_miniButton->Refresh();
 }
 void NotePanel::OnMinimizeButtonMouseLeave(wxMouseEvent& evt) {
-	m_minimizeHoverColor = DEFAULT_HOVER_COLOR;
+	m_minimizeHoverColor = HOVER_DEFAULT_COLOR;
 	m_miniButton->Refresh();
 }
 void NotePanel::OnMinimizeButtonMouseLeftDown(wxMouseEvent& evt) {
@@ -526,10 +573,17 @@ void NotePanel::OnCloseButtonMouseEnter(wxMouseEvent& evt) {
 	m_closeButton->Refresh();
 }
 void NotePanel::OnCloseButtonMouseLeave(wxMouseEvent& evt) {
-	m_closeHoverColor = DEFAULT_HOVER_COLOR;
+	m_closeHoverColor = HOVER_DEFAULT_COLOR;
 	m_closeButton->Refresh();
 }
 void NotePanel::OnCloseButtonMouseLeftDown(wxMouseEvent& evt) {
+	//do warning before delete the note
+	wxMessageDialog* dialog = new wxMessageDialog(this,
+		wxString::FromUTF8("Bạn muốn xóa ghi chú này?\nHành động này không thể hoàn tác"),
+		wxString::FromUTF8("Xác nhận"), wxYES_NO | wxCENTER | wxICON_WARNING);
+	dialog->SetYesNoLabels(wxString::FromUTF8("Có"), wxString::FromUTF8("Không"));
+	int ret = dialog->ShowModal();
+	if (ret != wxID_YES) return;
 	CHILD_CHANGED;
 	m_parent->DeleteNote(this);
 	this->Destroy();
@@ -553,10 +607,21 @@ void NotePanel::OnCloseButtonPaint(wxPaintEvent& evt) {
 }
 #pragma endregion
 
+
 void NotePanel::OnFocus(wxFocusEvent& evt) {//raise panel when received focus
 	auto window = static_cast<wxWindow*>(evt.GetEventObject());
 	if (window) {
 		this->Raise();
+	}
+	evt.Skip();
+}
+void NotePanel::OnMouseScroll(wxMouseEvent& evt) {
+	//scroll parent if the window dont have the scroll bar
+	wxWindow* window = static_cast<wxWindow*>(evt.GetEventObject());
+	if (window) {
+		if (window->GetScrollThumb(wxVERTICAL) == 0) {
+			m_parent->OnScroll(evt.GetWheelRotation(), evt.ControlDown(), evt.ShiftDown());
+		}
 	}
 	evt.Skip();
 }

--- a/NotePanel.h
+++ b/NotePanel.h
@@ -2,11 +2,13 @@
 #include <wx/wx.h>
 #include <wx/tokenzr.h>
 #include <wx/clipbrd.h>
+#include <wx/msgdlg.h>
 
 #include <string>
 #include "NotePanel_NotePad.h"
 
 #define DEFAULT_NOTE_PANEL_SIZE					(wxSize(250, 300))
+#define NOTE_PANEL_MIN_SIZE						(wxSize(150, 60))
 
 enum RESIZE_DIRECTION {
 	NONE,
@@ -36,6 +38,7 @@ public:
 	void SetHeaderText(wxString text);
 	void SetContentText(wxString text);
 	void SetMinimize(bool minimized);
+	void ResetToDefaultSize(bool resetWidth, bool resetHeight);
 
 	wxRect& GetOriginRect(void);
 	wxString GetHeaderText(void);
@@ -50,7 +53,7 @@ public:
 
 	void FromJson(wxString json);
 	wxString ToJson(void);
-protected:
+private:
 	//UI things
 	NoteHolderPanel* m_parent;
 	wxPanel* m_dragPanel;
@@ -86,6 +89,8 @@ protected:
 	void CreateNotePad(NOTE_TYPE_e type);
 	RESIZE_DIRECTION GetCurrentResizeDirection(wxPoint mousePos);
 	void BindingEventRecursive(wxWindow* window);
+	wxSize GetChildSizeDiff(void); // get the size different between m_notepad and the note its self 
+
 	//on drag panel
 	void OnDragPanelMouseMove(wxMouseEvent& evt);
 	void OnDragPanelMouseLeftDown(wxMouseEvent& evt);
@@ -93,7 +98,9 @@ protected:
 	void OnDragPanelMouseLeave(wxMouseEvent& evt); 
 	//on textctrl
 	void OnHeaderTextChanged(wxCommandEvent& evt);
+	void OnHeaderCharHook(wxKeyEvent& evt);
 	//on this ( resizing )
+	void OnResize(wxSizeEvent& evt);
 	void OnMouseMove(wxMouseEvent& evt);
 	void OnMouseLeave(wxMouseEvent& evt);
 	void OnMouseLeftDown(wxMouseEvent& evt);
@@ -112,123 +119,8 @@ protected:
 
 	//recursive events
 	void OnFocus(wxFocusEvent& evt);
+	void OnMouseScroll(wxMouseEvent& evt);
 };
 
 #include "NoteManager.h"
 #include "NoteHolderPanel.h"
-
-/*
-#pragma once
-#include <wx/wx.h>
-#include <wx/tokenzr.h>
-#include <wx/clipbrd.h>
-
-#include <string>
-
-#define DEFAULT_NOTE_PANEL_SIZE					(wxSize(250, 300))
-
-enum RESIZE_DIRECTION {
-	NONE,
-	LEFT,
-	BOTTOMLEFT,
-	BOTTOM,
-	BOTTOMRIGHT,
-	RIGHT
-};
-
-class NoteHolderPanel;
-
-class NotePanel : public wxPanel
-{
-public:
-	NotePanel(NoteHolderPanel* parent, int id = -1, wxPoint pos = wxDefaultPosition, wxSize size = wxSize(1, 1));
-
-	bool operator == (NotePanel* other);
-	bool operator != (NotePanel* other);
-
-	void SetColor(wxColour color);
-	void SetDragPanelColor(wxColour color);
-	void SetFontScale(float scalar);
-	void SetOriginRect(wxRect rect);
-	void SetHeaderFontSize(int size);
-	void SetContentFontSize(int size);
-	void SetHeaderText(wxString text);
-	void SetContentText(wxString text);
-	void SetMinimize(bool minimized);
-
-	wxRect& GetOriginRect(void);
-	wxString GetHeaderText(void);
-	wxString GetContentText(void);
-
-	void UpdateOnZoom(void);//take action when zoom in or out
-
-	void FromJson(wxString json);
-	wxString ToJson(void);
-protected:
-	//UI things
-	NoteHolderPanel* m_parent;
-	wxPanel* m_dragPanel;
-	wxTextCtrl* m_headerTC;
-	wxTextCtrl* m_contentTC;
-	wxRect m_originRect;
-	wxButton* m_miniButton;
-	wxButton* m_closeButton;
-	int m_headerFontSize;
-	int m_contentFontSize;
-	wxColour m_minimizeHoverColor;//hover color for minimize button
-	wxColour m_closeHoverColor;//hover color for close button
-	bool m_rightDown;
-	wxMenu* m_contextMenu; // right click menu=
-
-	//private usage for resizing panel
-	wxPoint m_prevRectPos;//save rect position when left down
-	wxSize m_prevRectSize;//save rect size when left down
-	wxPoint m_prevMousePos;//save mouse position when left down
-	wxPoint m_prevPanelPos;
-	wxSize m_prevPanelSize;
-	RESIZE_DIRECTION m_resizeDirection;
-
-	wxSize m_originSize;//save size for un-minimizing
-	bool m_isMinimized;
-
-	//global usage for all notes in parent when dragging notes
-	static wxPoint s_delta;//mouse offset from topleft when left down
-	static wxPoint s_panelPos;//panel position when left down
-	static wxPoint s_rectPos;//hold origin rect position when left is down
-
-	void Init(NoteHolderPanel* parent, int id, wxPoint pos, wxSize size);
-	RESIZE_DIRECTION GetCurrentResizeDirection(wxPoint mousePos);
-	void BindingEventRecursive(wxWindow* window);
-	void BuildContextMenu(void);
-	//on drag panel
-	void OnDragPanelMouseMove(wxMouseEvent& evt);
-	void OnDragPanelMouseLeftDown(wxMouseEvent& evt);
-	void OnDragPanelMouseLeftUp(wxMouseEvent& evt);
-	void OnDragPanelMouseLeave(wxMouseEvent& evt);
-	//on textctrl
-	void OnTextChanged(wxCommandEvent& evt);
-	void OnCharHook(wxKeyEvent& evt);
-	void OnTextPaste(wxClipboardTextEvent& evt);
-	//on this ( resizing )
-	void OnMouseMove(wxMouseEvent& evt);
-	void OnMouseLeave(wxMouseEvent& evt);
-	void OnMouseLeftDown(wxMouseEvent& evt);
-	void OnMouseLeftUp(wxMouseEvent& evt);
-	void OnContextMenu(wxContextMenuEvent& evt);
-
-	void OnMinimizeButtonMouseEnter(wxMouseEvent& evt);
-	void OnMinimizeButtonMouseLeave(wxMouseEvent& evt);
-	void OnMinimizeButtonMouseLeftDown(wxMouseEvent& evt);
-	void OnMinimizeButtonPaint(wxPaintEvent& evt);
-
-	void OnCloseButtonMouseEnter(wxMouseEvent& evt);
-	void OnCloseButtonMouseLeave(wxMouseEvent& evt);
-	void OnCloseButtonMouseLeftDown(wxMouseEvent& evt);
-	void OnCloseButtonPaint(wxPaintEvent& evt);
-
-	//recursive events
-	void OnFocus(wxFocusEvent& evt);
-};
-
-#include "NoteManager.h"
-#include "NoteHolderPanel.h"*/

--- a/NotePanel_NotePad.cpp
+++ b/NotePanel_NotePad.cpp
@@ -20,6 +20,9 @@ wxString NotePad::ToJson(void) {
 NOTE_TYPE_e NotePad::GetType(void) {
 	return NOT_SET;
 }
+void NotePad::ReceiveTabNavigation(void) {
+
+}
 
 void NotePad::SetColor(wxColour color) {
 	this->SetBackgroundColour(color);

--- a/NotePanel_NotePad.h
+++ b/NotePanel_NotePad.h
@@ -10,7 +10,7 @@ enum NOTE_TYPE_e {
 class NotePanel;
 
 class NotePad : public wxWindow
-{
+{//base class for variants of pad: textpad, listpad
 public:
 	NotePad(NotePanel* parent);
 
@@ -18,6 +18,8 @@ public:
 	virtual void SetContentFontSize(int size);
 
 	virtual NOTE_TYPE_e GetType(void);
+
+	virtual void ReceiveTabNavigation(void);
 
 
 	virtual void FromJson(wxString json);

--- a/NotePanel_TextPad.cpp
+++ b/NotePanel_TextPad.cpp
@@ -3,9 +3,18 @@
 #define JSON_START_MARK							(wxString("@#$"))
 #define JSON_END_MARK							(wxString("$#@"))
 
+//use this macro whenever you wish to change the data
 #define CHILD_CHANGED							(m_parent->OnChildChanged())
 
 extern void SetStatusText(wxString text, int index = 0);
+
+//menu id
+const int wxID_FIT_CONTENT = wxNewId();
+const int wxID_ERASE_ALL = wxNewId();
+const int wxID_SELECT_ALL = wxNewId();
+const int wxID_FIXED_WIDTH = wxNewId();
+const int wxID_FIXED_HEIGHT = wxNewId();
+const int wxID_FIXED_SIZE = wxNewId();
 
 static int GetLineMaxWidth(wxWindow* window, wxString content) {
 	int maxWidth = 0;
@@ -18,13 +27,32 @@ static int GetLineMaxWidth(wxWindow* window, wxString content) {
 	return maxWidth;
 }
 
+static wxString GetDataFromClipboard(void) {
+	//return empty string if there is no data from the clipbord
+	wxClipboard clipboard;
+	if (clipboard.Open()) {
+		if (clipboard.IsSupported(wxDF_TEXT)) {
+			wxTextDataObject data;
+			clipboard.GetData(data);
+			return data.GetText();//get pasted text
+		}
+		clipboard.Close();
+	}
+	return "";
+}
 
 TextPad::TextPad(NotePanel* parent)
 	: NotePad(parent) {
 #pragma region Init
+	m_isFixedWidth = false;
+	m_isFixedHeight = false;
 	m_parent = parent;
-	m_tctrl = new wxTextCtrl(this, -1, "", wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER | wxTE_MULTILINE | wxTE_NO_VSCROLL | wxBORDER_SIMPLE);
+	m_tctrl = new wxTextCtrl(this, -1, "", wxDefaultPosition, wxDefaultSize, 
+		wxTE_PROCESS_ENTER | wxTE_MULTILINE | wxBORDER_SIMPLE);
+	m_tctrl->SetName("tctrl");
+	this->SetName("TextPad");
 	BuildContextMenu();
+
 #pragma endregion
 
 
@@ -37,13 +65,28 @@ TextPad::TextPad(NotePanel* parent)
 
 
 #pragma region Binding
-	m_tctrl->Bind(wxEVT_CHAR_HOOK, &TextPad::OnCharHook, this);
-	m_tctrl->Bind(wxEVT_TEXT_PASTE, &TextPad::OnTextPaste, this);
-	m_tctrl->Bind(wxEVT_CONTEXT_MENU, &TextPad::OnContextMenu, this);
-	m_tctrl->Bind(wxEVT_RIGHT_DOWN, &TextPad::OnRightDown, this);
-	m_tctrl->Bind(wxEVT_TEXT, &TextPad::OnTextChanged, this);
+	//this
+	{
+		this->Bind(wxEVT_SIZE, &TextPad::OnResize, this);
+		
+	}
+
+	//m_tctrl
+	{
+		m_tctrl->Bind(wxEVT_CHAR_HOOK, &TextPad::OnCharHook, this);
+		m_tctrl->Bind(wxEVT_TEXT_PASTE, &TextPad::OnTextPaste, this);
+		m_tctrl->Bind(wxEVT_CONTEXT_MENU, &TextPad::OnContextMenu, this);
+		m_tctrl->Bind(wxEVT_RIGHT_DOWN, &TextPad::OnRightDown, this);
+		m_tctrl->Bind(wxEVT_TEXT, &TextPad::OnTextChanged, this);
+	}
+
+	//m_contextMenu
+	{
+		m_contextMenu->Bind(wxEVT_UPDATE_UI, &TextPad::OnMenuUpdateUI, this);
+	}
 #pragma endregion
 
+	this->EnableScrollbar(wxVERTICAL, false);
 }
 /**************************************************************************
 *							PUBLIC MEMBER								  *
@@ -59,6 +102,10 @@ void TextPad::SetContentFontSize(int size) {
 
 NOTE_TYPE_e TextPad::GetType(void) {
 	return TEXT;
+}
+void TextPad::ReceiveTabNavigation(void) {
+	m_tctrl->SetFocus();
+	m_tctrl->SetInsertionPointEnd();
 }
 
 void TextPad::FromJson(wxString json) {
@@ -79,72 +126,85 @@ wxString TextPad::ToJson(void) {
 **************************************************************************/
 #pragma region Private member
 #pragma region Events
+void TextPad::OnResize(wxSizeEvent& evt) {
+	this->Layout();
+	evt.Skip();
+}
 void TextPad::OnCharHook(wxKeyEvent& evt) {//adjust the height when user press enter
 	wxTextCtrl* tctrl = m_tctrl;
 	if (evt.GetKeyCode() == WXK_RETURN) {
-		//adjust the height to add new space
-		int lineHeight = tctrl->GetCharHeight();
-		int lineCount = tctrl->GetNumberOfLines() + 2;
-		int heightDelta = lineCount * lineHeight - tctrl->GetSize().y;
-		if (heightDelta > 0) {//overflow on height
-			wxSize newSize = wxSize(tctrl->GetSize().x, lineHeight * lineCount);
-			m_parent->OnChildSizeReport(newSize);
+		//only adjust the height if the user do not lock the height
+		if (m_isFixedHeight) {//lock the height -> do nothing
+			evt.Skip();
 		}
-		tctrl->WriteText("\n");
+		else { // not locking the height
+			//adjust the height to add new space
+			int lineHeight = tctrl->GetCharHeight();
+			int lineCount = tctrl->GetNumberOfLines() + 2;
+			int heightDelta = lineCount * lineHeight - tctrl->GetSize().y;
+			if (heightDelta > 0) {//overflow on height
+				wxSize newSize = wxSize(tctrl->GetSize().x, lineHeight * lineCount);
+				this->PrepareToSendSizeRequest(newSize);
+			}
+			tctrl->WriteText("\n");
+		}
+	}
+	else if (evt.GetKeyCode() == WXK_TAB) { // when user press tab, add 4 spaces to the control
+		tctrl->WriteText("    ");
 	}
 	else {
 		evt.Skip();
 	}
 }
-void TextPad::OnTextChanged(wxCommandEvent& evt) {
-	auto window = m_tctrl;
-	if (window) {
-		int charWidth = window->GetCharWidth() * 2;
-		int maxWidth = GetLineMaxWidth(window, window->GetValue());
-		
-		if ((maxWidth + charWidth) >= window->GetSize().x) {//overflow on width
-			wxSize newSize = window->GetSize();
-			newSize.x += charWidth * 2.0f;
-			m_parent->OnChildSizeReport(newSize);
+void TextPad::OnTextPaste(wxClipboardTextEvent& evt) {//add row when user paste text 
+	wxTextCtrl* window = m_tctrl;
+	wxString clipboardData = GetDataFromClipboard();
+	if (!clipboardData.IsEmpty()) {
+		//calculate number of row need to expand
+		int lineHeight = window->GetCharHeight();
+		int newLineCount = 0;
+		//count how many lines in the clipboard
+		{
+			wxStringTokenizer tokenizer(clipboardData, "\n");
+			while (tokenizer.HasMoreTokens()) {
+				newLineCount++;
+				wxString line = tokenizer.GetNextToken();
+			}
+		}
+
+		int clipboardHeight = lineHeight * newLineCount;
+		//get current content height of the textctrl
+		int contentHeight = window->GetCharHeight() * (window->GetNumberOfLines());
+		//adjust the height when adding new content overflow on height 
+		if (contentHeight + clipboardHeight > window->GetSize().y) {
+			wxSize newSize = wxSize(window->GetSize().x, contentHeight + clipboardHeight);
+			this->PrepareToSendSizeRequest(newSize);
 		}
 		CHILD_CHANGED;
 	}
 	evt.Skip();
 }
-void TextPad::OnTextPaste(wxClipboardTextEvent& evt) {//adjust row when user paste text 
-	wxTextCtrl* window = m_tctrl;
-	wxClipboard clipboard;
-	if (clipboard.Open()) {
-		if (clipboard.IsSupported(wxDF_TEXT)) {
-			wxTextDataObject data;
-			clipboard.GetData(data);
-			wxString pastedText = data.GetText();//get pasted text
+void TextPad::OnTextChanged(wxCommandEvent& evt) {
+	//adjust the width as the user typing too long text
+	if (m_isFixedWidth) return; // not possible to expand on width
+	auto window = m_tctrl;
+	if (window) {
+		int charWidth = window->GetCharWidth() * 2; //idk but * 2 works just fine
+		int maxWidth = GetLineMaxWidth(window, window->GetValue());
 
-			//calculate number of row need to expand
-			int lineHeight = window->GetCharHeight();
-			int newLineCount = 0;
-			wxStringTokenizer tokenizer(pastedText, "\n");
-			while (tokenizer.HasMoreTokens()) {
-				newLineCount++;
-				wxString line = tokenizer.GetNextToken();
-			}
-			int clipboardHeight = lineHeight * newLineCount;
-
-			//get current content height of the textctrl
-			int contentHeight = window->GetCharHeight() * (window->GetNumberOfLines());
-			//adjust the height when adding new content overflow on height 
-			if (contentHeight + clipboardHeight > window->GetSize().y) {
-				wxSize newSize = wxSize(window->GetSize().x, contentHeight + clipboardHeight);
-				m_parent->OnChildSizeReport(newSize);
-			}
-			CHILD_CHANGED;
+		if ((maxWidth + charWidth) >= window->GetSize().x) {//overflow on width
+			wxSize newSize = window->GetSize();
+			newSize.x += charWidth * 2.0f;
+			this->PrepareToSendSizeRequest(newSize);
 		}
-		clipboard.Close();
+		CHILD_CHANGED;
 	}
 	evt.Skip();
 }
 void TextPad::OnContextMenu(wxContextMenuEvent& evt) {
 	if (m_rightDown) {
+		//this->BuildContextMenu();
+		m_contextMenu->UpdateUI();
 		auto clientPos = evt.GetPosition() == wxDefaultPosition ?
 			(wxPoint(this->GetSize().GetWidth() / 2, this->GetSize().GetHeight() / 2))
 			: this->ScreenToClient(evt.GetPosition());
@@ -157,6 +217,63 @@ void TextPad::OnRightDown(wxMouseEvent& evt) {
 	m_rightDown = true;
 	evt.Skip();
 }
+void TextPad::OnMenuUpdateUI(wxUpdateUIEvent& evt) {
+	auto owner = m_tctrl;
+	auto copy = m_contextMenu->FindItem(wxID_COPY);
+	{
+		if (copy) {
+			copy->Enable(owner->CanCopy());
+		}
+	}
+	auto cut = m_contextMenu->FindItem(wxID_CUT);
+	{
+		if (cut) {
+			cut->Enable(owner->CanCut());
+		}
+	}
+	auto paste = m_contextMenu->FindItem(wxID_PASTE);
+	{
+		if (paste) {
+			paste->Enable(owner->CanPaste());
+		}
+	}
+	auto undo = m_contextMenu->FindItem(wxID_UNDO);
+	{
+		if (undo) {
+			undo->Enable(owner->CanUndo());
+		}
+	}
+	auto redo = m_contextMenu->FindItem(wxID_REDO);
+	{
+		if (redo) {
+			redo->Enable(owner->CanRedo());
+		}
+	}
+	auto fixedWidth = m_contextMenu->FindItem(wxID_FIXED_WIDTH);
+	{
+		if (fixedWidth) {
+			if (m_isFixedWidth) {
+				fixedWidth->SetItemLabel(wxString::FromUTF8("Hủy cố định chiều rộng"));
+			}
+			else {
+				fixedWidth->SetItemLabel(wxString::FromUTF8("Cố định chiều rộng"));
+			}
+			fixedWidth->Check(m_isFixedWidth);
+		}
+	}
+	auto fixedHeight = m_contextMenu->FindItem(wxID_FIXED_HEIGHT);
+	{
+		if (fixedHeight) {
+			if (m_isFixedHeight) {
+				fixedHeight->SetItemLabel(wxString::FromUTF8("Hủy cố định chiều cao"));
+			}
+			else {
+				fixedHeight->SetItemLabel(wxString::FromUTF8("Cố định chiều cao"));
+			}
+			fixedHeight->Check(m_isFixedHeight);
+		}
+	}
+}
 
 #pragma endregion
 
@@ -165,32 +282,29 @@ void TextPad::BuildContextMenu(void) {
 	auto owner = m_tctrl;
 	m_contextMenu = new wxMenu();
 
-	auto fitContent = m_contextMenu->Append(wxID_ANY, wxString::FromUTF8("Tùy chỉnh kích thước tự động"));
-	auto eraseContent = m_contextMenu->Append(wxID_ANY, wxString::FromUTF8("Xóa nội dung"));
+	auto selectAll = m_contextMenu->Append(wxID_SELECT_ALL, wxString::FromUTF8("Chọn toàn bộ nội dung \t Ctrl + A"));
+	auto eraseContent = m_contextMenu->Append(wxID_ERASE_ALL, wxString::FromUTF8("Xóa nội dung"));
+	auto copy = m_contextMenu->Append(wxID_COPY, wxString::FromUTF8("Sao chép \t Ctrl + C"));
+	auto paste = m_contextMenu->Append(wxID_PASTE, wxString::FromUTF8("Dán \t Ctrl + V"));
+	auto cut = m_contextMenu->Append(wxID_CUT, wxString::FromUTF8("Cắt \t Ctrl + X"));
+	auto undo = m_contextMenu->Append(wxID_UNDO, wxString::FromUTF8("Hoàn tác\tCtrl + Z"));
+	auto redo = m_contextMenu->Append(wxID_REDO, wxString::FromUTF8("Hủy hoàn tác\tCtrl + Y"));
 	m_contextMenu->AppendSeparator();
-	auto selectAll = m_contextMenu->Append(wxID_ANY, wxString::FromUTF8("Chọn toàn bộ nội dung \t Ctrl + A"));
-	auto copy = m_contextMenu->Append(wxID_ANY, wxString::FromUTF8("Sao chép \t Ctrl + C"));
-	auto paste = m_contextMenu->Append(wxID_ANY, wxString::FromUTF8("Dán \t Ctrl + V"));
-	auto cut = m_contextMenu->Append(wxID_ANY, wxString::FromUTF8("Cắt \t Ctrl + X"));
+	auto fitContent = m_contextMenu->Append(wxID_FIT_CONTENT, wxString::FromUTF8("Tùy chỉnh kích thước tự động"));
+	auto fixedWidth = m_contextMenu->AppendCheckItem(wxID_FIXED_WIDTH, wxString::FromUTF8("Cố định chiều rộng"));
+	auto fixedHeight = m_contextMenu->AppendCheckItem(wxID_FIXED_HEIGHT, wxString::FromUTF8("Cố định chiều cao"));
 
+	wxAcceleratorEntry entries[1];
+	entries[0].Set(wxACCEL_CTRL, (int)'Y', redo->GetId());
+	
+	wxAcceleratorTable table(1, entries);
+	owner->SetAcceleratorTable(table);
 
-	this->Bind(wxEVT_MENU, [=](wxCommandEvent& evt) {
-		//find the text size and fit it
-		wxClientDC dc(owner);
-		wxSize textSize = dc.GetMultiLineTextExtent(owner->GetValue());
-		wxSize minSize = m_parent->GetMinSize();
-		//add some padding
-		textSize.x += owner->GetCharWidth() * 2;
-		textSize.y += owner->GetCharHeight();
-		//clamp the size
-		textSize.x = SharedData::Max(textSize.x, minSize.x);
-		textSize.y = SharedData::Max(textSize.y, minSize.y);
-		m_parent->OnChildSizeReport(textSize);
-		CHILD_CHANGED;
-		//this->UpdateOnZoom();//update the note after set size
+	this->Bind(wxEVT_MENU, [this](wxCommandEvent& evt) {
+		this->SetSizeToFitContent(true, true);
 		}, fitContent->GetId());
 	this->Bind(wxEVT_MENU, [=](wxCommandEvent& evt) {
-		owner->SetValue("");
+		owner->Clear();
 		CHILD_CHANGED;
 		}, eraseContent->GetId());
 	this->Bind(wxEVT_MENU, [=](wxCommandEvent& evt) {
@@ -205,6 +319,108 @@ void TextPad::BuildContextMenu(void) {
 	this->Bind(wxEVT_MENU, [=](wxCommandEvent& evt) {
 		owner->Cut();
 		}, cut->GetId());
+	this->Bind(wxEVT_MENU, [=](wxCommandEvent& evt) {
+		owner->Undo();
+		}, undo->GetId());
+	this->Bind(wxEVT_MENU, [=](wxCommandEvent& evt) {
+		owner->Redo();
+		}, redo->GetId());
+	this->Bind(wxEVT_MENU, [=](wxCommandEvent& evt) {
+		m_isFixedWidth = !m_isFixedWidth;
+		this->SetFixedWidth(m_isFixedWidth);
+		}, fixedWidth->GetId());
+	this->Bind(wxEVT_MENU, [=](wxCommandEvent& evt) {
+		m_isFixedHeight = !m_isFixedHeight;
+		this->SetFixedHeight(m_isFixedHeight);
+		}, fixedHeight->GetId());
+}
+void TextPad::SetFixedWidth(bool isFixed) {
+	return;
+	int scrollbarWidth = 15;
+	auto window = m_tctrl;
+	if (isFixed) {
+		//show the vertical scroll bar
+		m_tctrl->SetScrollbar(wxVERTICAL, 0, 20, 50);
+		
+		//increase the width after add the scrollbar
+		wxSize newSize = this->GetSize();
+		newSize.SetWidth(newSize.GetWidth() + scrollbarWidth);
+		this->PrepareToSendSizeRequest(newSize);
+	}
+	else {
+
+		//hide the vertical scroll bar
+		m_tctrl->SetScrollbar(wxVERTICAL, 0, 0, 0);
+		//expand the height to fit the content
+		this->SetSizeToFitContent(false, true);
+
+		//descrease the size when remove scrollbar
+		wxSize newSize = this->GetSize();
+		newSize.SetWidth(newSize.GetWidth() - scrollbarWidth);
+		this->PrepareToSendSizeRequest(newSize);
+	}
+}
+void TextPad::SetFixedHeight(bool isFixed) {
+	int scrollbarWidth = 15;
+	auto window = m_tctrl;
+	if (isFixed) {
+		//show the vertical scroll bar
+		this->EnableScrollbar(wxVERTICAL);
+
+		//increase the width after add the scrollbar
+		wxSize newSize = this->GetSize();
+		newSize.SetWidth(newSize.GetWidth() + scrollbarWidth);
+		this->PrepareToSendSizeRequest(newSize);
+	}
+	else {
+		//hide the vertical scroll bar
+		this->EnableScrollbar(wxVERTICAL, false);
+		//expand the height to fit the content
+		this->SetSizeToFitContent(false, true);
+
+		//descrease the size when remove scrollbar
+		wxSize newSize = this->GetSize();
+		newSize.SetWidth(newSize.GetWidth() - scrollbarWidth);
+		this->PrepareToSendSizeRequest(newSize);
+	}
+}
+void TextPad::SetFixedSize(bool fixedWidth, bool fixedHeight) {
+	this->SetFixedWidth(fixedWidth);
+	this->SetFixedHeight(fixedHeight);
+}
+void TextPad::EnableScrollbar(int direction, bool enable) {
+	auto window = m_tctrl;
+	if (enable) {
+		window->SetScrollbar(direction, 0, 20, 50);
+	}
+	else {
+		window->SetScrollbar(direction, 0, 0, 0);
+	}
+}
+void TextPad::PrepareToSendSizeRequest(wxSize newSize) {
+	//this class is not allow to change their size directly
+	//when the control wish to change the size, call this function to report to the parent
+	m_parent->OnChildSizeReport(newSize);
+}
+void TextPad::SetSizeToFitContent(bool fitWidth, bool fitHeight) {
+	if (!fitWidth && !fitHeight) return; // nothing to change here
+	auto window = m_tctrl;
+	wxClientDC dc(window);
+	//find the text size and fit it
+	wxSize newSize = dc.GetMultiLineTextExtent(window->GetValue()); // the size request for the text
+	wxSize minSize = m_parent->GetMinSize();
+	//add some padding
+	newSize.x += window->GetCharWidth() * 3;
+	newSize.y += window->GetCharHeight();
+
+	if (!fitWidth) {//keep the width un-change
+		newSize.SetWidth(window->GetSize().GetWidth());
+	}
+	if (!fitHeight) {//keep the height un-change
+		newSize.SetHeight(window->GetSize().GetHeight());
+	}
+	this->PrepareToSendSizeRequest(newSize);
+	CHILD_CHANGED;
 }
 #pragma endregion
 /**************************************************************************

--- a/NotePanel_TextPad.h
+++ b/NotePanel_TextPad.h
@@ -16,18 +16,34 @@ public:
 
 	virtual NOTE_TYPE_e GetType(void);
 
+	virtual void ReceiveTabNavigation(void);
+
+
 	virtual void FromJson(wxString json);
 	virtual wxString ToJson(void);
+	void SetSizeToFitContent(bool fitWidth, bool fitHeight);
+
 private:
 	bool m_rightDown;
 	wxTextCtrl* m_tctrl;
 	wxMenu* m_contextMenu;
-	void BuildContextMenu(void);
+	bool m_isFixedWidth;
+	bool m_isFixedHeight;
 
+	void BuildContextMenu(void);
+	void PrepareToSendSizeRequest(wxSize newSize);//check for the object is good to send size request
+	void SetFixedWidth(bool isFixed = true);
+	void SetFixedHeight(bool isFixed = true);
+	void SetFixedSize(bool fixedWidth = true, bool fixedHeight = true);
+	void EnableScrollbar(int direction, bool enable = true);//direction = wxVERTICAL | wxHORIZONTAL
+
+	void OnResize(wxSizeEvent& evt);
 	void OnContextMenu(wxContextMenuEvent& evt);
 	void OnCharHook(wxKeyEvent& evt);
 	void OnTextChanged(wxCommandEvent& evt);
 	void OnTextPaste(wxClipboardTextEvent& evt);
 	void OnRightDown(wxMouseEvent& evt);
+	
+	void OnMenuUpdateUI(wxUpdateUIEvent& evt);
 };
 


### PR DESCRIPTION
- When the user set the width to fixed, the text will be wrapped when they getting longer than the note width
- When the user set the height to fixed, a vertical scrollbar will be added to the note so the height of the note wont be expanded